### PR TITLE
Resolving CAE violations 

### DIFF
--- a/src/data_access/text_file/FileStationDataAccessObject.java
+++ b/src/data_access/text_file/FileStationDataAccessObject.java
@@ -82,6 +82,7 @@ public class FileStationDataAccessObject implements SearchDataAccessInterface, S
         return stations.get(inputStationName);
     }
 
+    @Override
     public void setStationAmenities(Station stationObj, List<String> stationObjAmenities){
         // Assigning the Station obj's amenitiesList attribute to a valid value
         stationObj.setAmenitiesList(stationObjAmenities);
@@ -90,7 +91,7 @@ public class FileStationDataAccessObject implements SearchDataAccessInterface, S
     @Override
     public List<Train> getIncomingVehicles(String inputStationName) {
         if (incomingVehiclesNotEmpty(inputStationName)) {
-            String stationId = getStationId(inputStationName);
+            String stationId = getStationID(inputStationName);
             List<Train> incomingVehiclesList = new ArrayList<>();
             for (List<String> vehicles : goVehicleApiClass.retrieveVehicleInfo(stationId)) {
                 String lineCode = vehicles.get(0);
@@ -112,20 +113,13 @@ public class FileStationDataAccessObject implements SearchDataAccessInterface, S
         else {return null;}
     }
 
-    // TODO: We will leave two getStationid() method for now, and will resolve it later
-    // TODO: One is for @Override in StationInfoDataAccessInterface and one is for
-    //  retrieving station id in other override method
-    @Override
-    public String getStationId(String inputStationName) {
-        return (stations.get(inputStationName)).getId();
-    }
-
     @Override
     public String getStationParentLine(String inputStationName) {
 
         return (stations.get(inputStationName)).getParentLine();
     }
 
+    @Override
     public String getStationID (String inputStationName) {
 
         return (stations.get(inputStationName)).getId();
@@ -139,6 +133,7 @@ public class FileStationDataAccessObject implements SearchDataAccessInterface, S
         return stationAmenitiesList;
     }
 
+    @Override
     public boolean stationExist(String identifier){
         return stations.containsKey(identifier); //TODO: MASSIVE ASSUMPTION HERE THAT THE USER types input in correct casing
                                                  // May need to resolve this by converting user input to lowercase -> then comparing to txt names (which will also be compared in lowercase form?)

--- a/src/interface_adapter/search/SearchPresenter.java
+++ b/src/interface_adapter/search/SearchPresenter.java
@@ -21,8 +21,6 @@ public class SearchPresenter implements SearchOutputBoundary {
         String retrieveStationName = response.getStationName();
         String retrieveStationAmenities = response.getStationAmenities();
         String retrieveParentLine = response.getStationParentLine();
-        // TODO: Left NOTE BELOW FOR TESTING PURPOSES ONLY. Delete in final implementation
-        // In the above, changing the arguments to String retrieveStationParentLine = response.getStationParentLine(); would display the Parent line of station
 
         // Step 1: Resetting the station error value in the searchState to be null (in case any failed search attempts came before this "successful" attempt)
         SearchState searchState = searchViewModel.getState();

--- a/src/use_case/search/SearchDataAccessInterface.java
+++ b/src/use_case/search/SearchDataAccessInterface.java
@@ -8,10 +8,14 @@ public interface SearchDataAccessInterface {
 
     // new method added to check whether the station whose name the user inputs ACTUALLY exists in the data object
     boolean stationExist(String identifier);
+
+    String getStationID (String inputStationName);
     Station getStation(String inputStationName); // attempting to only get proper station name for base implementation of team use case
     // used to be: Station getStation(); above
     String getStationParentLine(String inputStationName);
 
     List<String> getStationAmenities(String inputStationName);
+
+    void setStationAmenities(Station stationObj, List<String> stationObjAmenities);
 
 }

--- a/src/use_case/station_info/StationInfoDataAccessInterface.java
+++ b/src/use_case/station_info/StationInfoDataAccessInterface.java
@@ -11,7 +11,4 @@ public interface StationInfoDataAccessInterface {
     Station getStation(String inputStationName);
 
     List<Train> getIncomingVehicles(String inputStationName);
-
-    String getStationId(String inputStationName);
-    // We might not need this since we could get station id from getStation().
 }


### PR DESCRIPTION
## Description 
This PR fixes CAE violations that were found in files `FileStationDataAccessObject` and the interfaces that it inherits `SearchDataAccessInterface` and `StationInfoDataAccessInterface`.

## Details

- Deleted duplicate method `getStationId `that was doing the same thing as `getStationID`
- Made methods `getStationID` and `setStationAmenities` to be overriden from `SearchDataAccessInterface`

## Relevant issues
N/A
