### PR TITLE
add project website link + readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,47 +6,62 @@
 </div>
 
 <!-- TODO: place graphics here once a working product is established -->
-This README file is yet to be updated. For now, please check the <a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">project website</a> for up-to-date info.
-## Project Domain
-Our project domain focuses on public transportation. We are developing a transit tracking application specific to the GO Transit network that allows commuters to find and receive data, so they can make well-informed decisions.
+<h2> About </h2>
+<p> TrackMyTransit is a group project for <a href="https://artsci.calendar.utoronto.ca/course/csc207h1">CSC207</a>
+    done by Aaron Aranda, Carmen Chau, Jacquelyn Lu, and Jason Barahan. (Their GitHub/LinkedIn profiles are
+linked at the bottom of the page.)</p>
 
-## The application
-Our team plans to develop a GUI-based application that allows users to input the name of a GO Train station, and receive information such as:
+<p> It is a GUI-based transport tracking application specific to the GO Transit network which relies on obtaining
+data using GET calls from <a href="http://api.openmetrolinx.com/OpenDataAPI/Help/Index/en"> GO Transit's own API</a>,
+    processing relevant information - like station amenities and incoming train departures - and displaying it to
+    the user. This program also relies on Bing's <i>REST Map Imagery API</i>.</p>
 
-- The different available amenities at this station
-- A list that includes incoming trains and buses to that station
+<p> Of course, we don't plan on monetizing this. This was purely for our own educational purposes.</p>
 
-Furthermore, users will be allowed to access more information about each individual incoming train and bus to the station they are viewing, this includes:
-
-- A map plotting the location of the incoming train or bus (using the latitude and longitude coordinates) 
-- Getting the estimated time of arrival AND the scheduled time of arrive of the train/bus to that station. Then, returning the time delay (ie: The difference between these 2 numbers) 
-
-This involves retrieving input data from users, organizing it into and retrieving data from API calls, displaying and visualizing data, and writing data (for frequently searched routes on a per-device basis).
-
-## API
-The API we are using is provided by <a href="http://api.openmetrolinx.com/OpenDataAPI/Help/Index/en">GO Transit</a>.
-
-A sample API call can be seen below (note: The actual API key that was used to generate this output has been omitted in screenshot for security reasons)
-
-GET REQUEST input: `http://api.openmetrolinx.com/OpenDataAPI/api/V1/Stop/NextService/UN?key=` (after the "=" sign, the API key is inserted)
-
-<img width="421" alt="Screenshot 2023-10-22 at 6 53 04 PM" src="https://github.com/JasonBarahan/TrackMyTransit/assets/80921817/ae450211-dbd4-4f00-9149-0aa105319675">
-
-
-## Footnotes
+<h2>How does it work?</h2>
+Users can input a GO Train station name and receive information about it, such as:
 <ul>
-    <li> Our primary focus is on train services. We will focus on bus services to the extent that they substitute train services - one example is Barrie Line service being operated by buses outside of rush hour. Bus services not associated with train lines will not be included (yet).</li>
-    <li> This application is not endorsed by Metrolinx or any transit agency under the purview of Metrolinx.
+    <li>The station's amenities</li>
+    <li>The next departures from the train station</li>
+    <li>Information on departure delays</li>
+    <li>Visualizing those train positions on a map</li>
+</ul>
+<br>
+A visual demonstration of the program can be found in the slides posted below.
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQTt8evQ5RM4z6KbTX4TxbQOW2CbL5qalJxQywkRADR4FjGYm0s4ZMCMa742ZyDjhMV89hxUGwxmN-O/embed?start=false&loop=true&delayms=10000" frameborder="0" width="100%" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<br> Alternatively, you can access the slides <a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">here.</a>
+<h2>Design elements (and the project's purpose)</h2>
+<p>CSC207 is a course on software design - which taught us various principles such as Clean Architecture, SOLID
+design principles, design patterns, and object-oriented design. The course also focused on concepts such as
+    RESTful APIs. This project was meant to demonstrate and further develop our understanding of these principles
+    and concepts. A high-level overview is as follows:</p>
+<ul>
+    <li>Our program was created based on Clean Architecture and object-oriented design patterns. Classes were
+    organized based on Clean Architecture layers and implemented such that data is passed through layers at
+    specific points.</li>
+    <ul>
+        <li>To be more specific, we used the Model-View-Controller (MVC) pattern when deciding how to organize
+        our classes.</li>
+    </ul>
+    <li>Packages within our program were also influenced by Clean Architecture. The outer
+        layer was based on Clean Archiecture layer names. The inner layer within these packages were named after
+        specific use cases, such as visualization of trains. This minimized ambiguity within our codebase and
+        minimized time lost in the development timeline due to searching for specific files.</li>
+    <li>Various design patterns, such as <i>Factory</i> and <i>Observer</i> were used. Their UML diagrams can be
+    found in the <a href="resources.html">slides.</a></li>
+    <li>SOLID design principles were used to ensure the program could be easily modified in the future without
+    compromising the functionality of existing code, along other reasons. Some highlighted examples can be found
+    in our <a href="resources.html">slides.</a></li>
 </ul>
 
-### Links
-<!-- Some of the links here are empty and need to be filled. -->
+<h2>Acknowledgements</h2>
 <ul>
-    <li><a href="hthttp://api.openmetrolinx.com/OpenDataAPI/Help/Index/en">API documentation</a> courtesy of Metrolinx</li>
+    <li>GO Transit API courtesy of Metrolinx.</li>
+    <li>BING Maps API courtesy of Bing.</li>
 </ul>
 
-## Disclaimers
+<h2> Disclaimers </h2>
 <ul>
-    <li>Disclaimer #1: <br>"Route and arrival data used in this product or service is provided by permission of Metrolinx. Metrolinx assumes no responsibility for the accuracy or currency of the Data used in this product or service.”</li>
-    <li>Disclaimer #2: <br>"This application is for study (educational) purposes only.”</li>
+    <li>We are not affiliated with GO Transit, Metrolinx, or any other transit agency.</li>
+    <li>This program is for educational purposes only.</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ Users can input a GO Train station name and receive information about it, such a
     <li>Visualizing those train positions on a map</li>
 </ul>
 <br>
-A visual demonstration of the program can be found in the slides posted below.
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQTt8evQ5RM4z6KbTX4TxbQOW2CbL5qalJxQywkRADR4FjGYm0s4ZMCMa742ZyDjhMV89hxUGwxmN-O/embed?start=false&loop=true&delayms=10000" frameborder="0" width="100%" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
-<br> Alternatively, you can access the slides <a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">here.</a>
+A visual demonstration of the program can be found in the slides posted <a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">here.</a>
 <h2>Design elements (and the project's purpose)</h2>
 <p>CSC207 is a course on software design - which taught us various principles such as Clean Architecture, SOLID
 design principles, design patterns, and object-oriented design. The course also focused on concepts such as

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <div align='center'>
     <!-- project title is up for debate!! -->
     <h1><b>TrackMyTransit</b></h1>
-    <div>A project by Aaron Aranda, Carmen Chau, Jacquelyn Lu, and Jason Barahan</div>
+    <div>A project by Aaron Aranda, Carmen Chau, Jacquelyn Lu, and Jason Barahan
+<br><a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">Project website</a></div>
 </div>
 
 <!-- TODO: place graphics here once a working product is established -->
-
+This README file is yet to be updated. For now, please check the <a href="https://docs.google.com/presentation/d/11Zj77PYk7ggaJpTGcc7wBB_cS97FSSqaqtUPnrTcXIU/edit?usp=sharing">project website</a> for up-to-date info.
 ## Project Domain
 Our project domain focuses on public transportation. We are developing a transit tracking application specific to the GO Transit network that allows commuters to find and receive data, so they can make well-informed decisions.
 


### PR DESCRIPTION
## Description 
Add project website link; update README.md file (mark as to-do)

## Details
I've added a (quickly-assembled) project website in case interested hiring staff, prospective employers, or other people wish to comb through our work in a more high-level manner. I will update the README.md file to reflect most website content accordingly.

The site also includes a demonstration slideshow to show how the program would run, considering that this program requires an API key to function correctly (and also because the API key is restricted by Metrolinx).

Of course, your GitHub profiles and LinkedIn profiles (if applicable) are linked in the webpage footer. Let me know if there's any changes needed.
